### PR TITLE
Extension of the status comment field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ document, starting from its first beta draft version.
 
 0.3.0
 -----
- * Adding optional element `status-comment`.
+ * Adding optional element `comment`.
 
   The comment was present in the Outgoing Mobilities `update-statuses` request
   and was mistakenly ommitted when moving nomination acceptance from Outgoing
-  to Incoming Mobilities API.
+  to Incoming Mobilities API. The `comment` is now independent of `status`,
+  so it can be used more widely, eg. to notify partner about some strange situation.
 
 0.2.0
 -----

--- a/endpoints/get-response-example.xml
+++ b/endpoints/get-response-example.xml
@@ -10,13 +10,27 @@
     <student-mobility-for-studies>
         <omobility-id>c442c289-5541-4cae-9edb-8ad83e133613</omobility-id>
         <status>verified</status>
-        <actual-arrival-date>2010-02-05</actual-arrival-date>
-        <actual-departure-date>2010-06-19</actual-departure-date>
+        <actual-arrival-date>2018-02-05</actual-arrival-date>
+        <actual-departure-date>2018-06-19</actual-departure-date>
     </student-mobility-for-studies>
-    
+
     <student-mobility-for-studies>
         <omobility-id>d331d178-4430-3dbf-8fec-7be72f022502</omobility-id>
         <status>rejected</status>
-        <status-comment>The agreement applies to Master's studies. This is a PhD student.</status-comment>
+        <comment>The agreement applies to Master's studies. This is a PhD student.</comment>
+    </student-mobility-for-studies>
+
+    <student-mobility-for-studies>
+        <omobility-id>e220e067-3329-2ecg-7gfd-6cf61g911491</omobility-id>
+        <status>verified</status>
+        <comment>Student leaved after one week.</comment>
+        <actual-arrival-date>2018-06-03</actual-arrival-date>
+        <actual-departure-date>2018-06-10</actual-departure-date>
+    </student-mobility-for-studies>
+
+    <student-mobility-for-studies>
+        <omobility-id>f119f956-2218-1fdh-6hge-5dg50h800380</omobility-id>
+        <status>verified</status>
+        <comment>Student did not appeared at the university.</comment>
     </student-mobility-for-studies>
 </imobilities-get-response>

--- a/endpoints/get-response.xsd
+++ b/endpoints/get-response.xsd
@@ -107,12 +107,13 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-                <xs:element name="status-comment" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:element name="comment" type="xs:string" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             An optional comment. It is RECOMMENDED for comments to be provided only when
-                            necessary (i.e. when nominations are rejected). These comments MUST be visible only to the IRO
-                            members, not the students.
+                            necessary (e.g. when nominations are rejected, student did not appear on receiving HEI
+                            or leaved unexpectedly).
+                            These comments MUST be visible only to the IRO members, not the students.
 
                             Note, that this API allows for every mobility to have a different
                             comment. However, it is also okay for the clients to simply "batch copy" a single comment to all


### PR DESCRIPTION
Field "status-comment" was renamed to "comment".
Its description was changed, encouraging partners
to send comments when something strange happens
after nomination acceptance.